### PR TITLE
Basic support for multiple profiles

### DIFF
--- a/src/HideoutUtils.ts
+++ b/src/HideoutUtils.ts
@@ -38,7 +38,7 @@ export class HideoutUtils {
       hideoutAreas,
       profile
     );
-    const hideoutTracker = loadPityTrackerDatabase().hideout;
+    const hideoutTracker = loadPityTrackerDatabase(profile.info.id).hideout;
     return possibleUpgrades.flatMap(
       (possibleUpgrade): HideoutItemRequirement[] => {
         const tracker = hideoutTracker[possibleUpgrade.area];

--- a/src/QuestUtils.ts
+++ b/src/QuestUtils.ts
@@ -27,9 +27,10 @@ export class QuestUtils {
   constructor(private logger: ILogger) {}
 
   augmentQuestStatusesWithTrackingInfo(
+    profileId: string,
     questStatuses: IQuestStatus[]
   ): AugmentedQuestStatus[] {
-    const questTracker = loadPityTrackerDatabase().quests;
+    const questTracker = loadPityTrackerDatabase(profileId).quests;
     return questStatuses.map((questStatus) => ({
       ...questStatus,
       raidsSinceStarted: questTracker[questStatus.qid]?.raidsSinceStarted ?? 0,
@@ -42,6 +43,7 @@ export class QuestUtils {
   ): ItemRequirement[] {
     // augment inProgress Quests with # of raids since accepted
     const inProgressQuests = this.augmentQuestStatusesWithTrackingInfo(
+      profile.info.id,
       profile.characters.pmc.Quests.filter(
         (quest) =>
           (quest.qid !== "5c51aac186f77432ea65c552" || !excludeCollector) &&

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -135,7 +135,7 @@ class Mod implements IPreAkiLoadMod {
       { frequency: "Always" }
     );
 
-    maybeCreatePityTrackerDatabase();
+    // maybeCreatePityTrackerDatabase();
 
     function handlePityChange(sessionId: string, incrementRaidCount: boolean) {
       const fullProfile = profileHelper.getFullProfile(sessionId);


### PR DESCRIPTION
I added basic support for multiple profiles.

There is one database file per profile ID. Changes to the pity tracker are written into these separate files. Required to touch all places that call loadPityTrackerDatabase() as it now needs a profile ID.

Tested locally and under FIKA (loot changes are pulled from the raid host db file and only affect that same file).